### PR TITLE
fix: Improve media save handling and tests

### DIFF
--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -27,6 +27,7 @@ describe('Utils factory', () => {
 
   afterEach(async () => {
     await fs.rm(path.join(__dirname, '../media/__test__'), { recursive: true, force: true });
+    await fs.rm(path.join(__dirname, '../media/api/fr/api/rest_v1/page/pdf/Foo'), { force: true });
   });
 
   function createResponse() {
@@ -260,11 +261,25 @@ describe('Utils factory', () => {
 
     expect(result).toEqual({ success: true, path: savedPath });
     expect(mockGotStream).toHaveBeenCalledWith(
-      new URL('https://upload.wikimedia.org/__test__/Santa_Mar%C3%ADa_Catedral.jpg'),
+      'https://upload.wikimedia.org/__test__/Santa_Mar%C3%ADa_Catedral.jpg',
       { headers: { 'User-Agent': 'test-agent' } }
     );
     await expect(fs.readFile(savedPath, 'utf8')).resolves.toBe('image-bytes');
     await expect(fs.stat(`${savedPath}.download`)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  test('saveFile() streams from generated allow-listed upstream URLs', async () => {
+    const pdfPath = '/api/fr/api/rest_v1/page/pdf/Foo';
+    await fs.rm(path.join(__dirname, '../media/api/fr/api/rest_v1/page/pdf/Foo'), { force: true });
+    await utils.saveFile(
+      new URL('https://fr.wikipedia.org/api/rest_v1/page/pdf/Foo'),
+      pdfPath
+    );
+
+    expect(mockGotStream).toHaveBeenCalledWith(
+      'https://fr.wikipedia.org/api/rest_v1/page/pdf/Foo',
+      { headers: { 'User-Agent': 'test-agent' } }
+    );
   });
 
   test('saveFile() rejects path traversal and malformed encoded paths', async () => {

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -237,6 +237,16 @@ describe('Utils factory', () => {
     })).resolves.toEqual({ success: false, reason: 'SAVEFILE_ERROR' });
   });
 
+  test('validMediaUrl() only accepts expected Wikimedia media hosts', () => {
+    expect(utils.validMediaUrl(new URL('https://upload.wikimedia.org/wikipedia/commons/Foo.png'))).toBe(true);
+    expect(utils.validMediaUrl(new URL('https://maps.wikimedia.org/osm-intl/Foo.png'))).toBe(true);
+    expect(utils.validMediaUrl(new URL('https://wikimedia.org/api/rest_v1/media/Foo'))).toBe(true);
+    expect(utils.validMediaUrl(new URL('https://fr.wikipedia.org/api/rest_v1/page/pdf/Foo'))).toBe(true);
+    expect(utils.validMediaUrl(new URL('http://upload.wikimedia.org/wikipedia/commons/Foo.png'))).toBe(false);
+    expect(utils.validMediaUrl(new URL('https://example.org/wikipedia/commons/Foo.png'))).toBe(false);
+    expect(utils.validMediaUrl(new URL('https://not-a-lang.wikipedia.org/api/rest_v1/page/pdf/Foo'))).toBe(false);
+  });
+
   test('saveFile() retries and replaces zero-byte cached media files', async () => {
     const filePath = '/__test__/Santa_Mar%C3%ADa_Catedral.jpg';
     const savedPath = path.join(__dirname, '../media/__test__/Santa_María_Catedral.jpg');
@@ -255,6 +265,29 @@ describe('Utils factory', () => {
     );
     await expect(fs.readFile(savedPath, 'utf8')).resolves.toBe('image-bytes');
     await expect(fs.stat(`${savedPath}.download`)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  test('saveFile() rejects path traversal and malformed encoded paths', async () => {
+    await expect(utils.saveFile(
+      new URL('https://upload.wikimedia.org/wikipedia/commons/Foo.png'),
+      '/../wikiless.config'
+    )).resolves.toEqual({ success: false, reason: 'INVALID_MEDIA_PATH' });
+
+    await expect(utils.saveFile(
+      new URL('https://upload.wikimedia.org/wikipedia/commons/Foo.png'),
+      '/%E0%A4%A'
+    )).resolves.toEqual({ success: false, reason: 'INVALID_MEDIA_PATH' });
+
+    expect(mockGotStream).not.toHaveBeenCalled();
+  });
+
+  test('saveFile() rejects unexpected upstream media hosts before streaming', async () => {
+    await expect(utils.saveFile(
+      new URL('https://example.org/wikipedia/commons/Foo.png'),
+      '/wikipedia/commons/Foo.png'
+    )).resolves.toEqual({ success: false, reason: 'INVALID_MEDIA_URL' });
+
+    expect(mockGotStream).not.toHaveBeenCalled();
   });
 
   test('saveFile() removes incomplete temp files when downloads fail', async () => {

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -223,7 +223,7 @@ describe('Utils factory', () => {
 
     expect(utils.saveFile).toHaveBeenCalledWith(
       new URL('https://upload.wikimedia.org/wikipedia/commons/thumb/9/9e/Santa_Mar%C3%ADa_Catedral_-_Chiclayo.jpg/500px-Santa_Mar%C3%ADa_Catedral_-_Chiclayo.jpg'),
-      '/wikipedia/commons/thumb/9/9e/Santa_Mar%C3%ADa_Catedral_-_Chiclayo.jpg/500px-Santa_Mar%C3%ADa_Catedral_-_Chiclayo.jpg'
+      '/wikipedia/commons/thumb/9/9e/Santa_María_Catedral_-_Chiclayo.jpg/500px-Santa_María_Catedral_-_Chiclayo.jpg'
     );
   });
 

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -5,21 +5,28 @@ jest.mock('../wikiless.config', () => ({
   setexs: { wikipage: 3600 },
 }));
 
+const fs = require('fs').promises;
 const path = require('path');
+const { Readable } = require('stream');
 const Utils = require('../src/utils.js');
 
 describe('Utils factory', () => {
-  let fakeRedis, utils;
+  let fakeRedis, mockGotStream, utils;
 
   beforeEach(() => {
+    mockGotStream = jest.fn(() => Readable.from(['image-bytes']));
     fakeRedis = {
       get:    jest.fn().mockResolvedValue(null),
       setEx:  jest.fn().mockResolvedValue('OK'),
       isOpen: false,
       connect: jest.fn().mockResolvedValue(),
     };
-    utils = new Utils(fakeRedis);
+    utils = new Utils(fakeRedis, { stream: (...args) => mockGotStream(...args) });
     global.protocol = 'https://';
+  });
+
+  afterEach(async () => {
+    await fs.rm(path.join(__dirname, '../media/__test__'), { recursive: true, force: true });
   });
 
   function createResponse() {
@@ -203,6 +210,23 @@ describe('Utils factory', () => {
     expect(utils.saveFile.mock.calls[3][1]).toBe('/api/fr/api/rest_v1/page/pdf/Foo');
   });
 
+  test('proxyMedia() preserves encoded Wikimedia thumbnail paths', async () => {
+    utils.saveFile = jest.fn(async (url, filePath) => ({ success: true, path: `SAVED:${filePath}:${url.href}` }));
+    const encodedPath = '/media/wikipedia/commons/thumb/9/9e/Santa_Mar%C3%ADa_Catedral_-_Chiclayo.jpg/500px-Santa_Mar%C3%ADa_Catedral_-_Chiclayo.jpg';
+
+    await utils.proxyMedia({
+      url: encodedPath,
+      query: {},
+      cookies: {},
+      params: {},
+    });
+
+    expect(utils.saveFile).toHaveBeenCalledWith(
+      new URL('https://upload.wikimedia.org/wikipedia/commons/thumb/9/9e/Santa_Mar%C3%ADa_Catedral_-_Chiclayo.jpg/500px-Santa_Mar%C3%ADa_Catedral_-_Chiclayo.jpg'),
+      '/wikipedia/commons/thumb/9/9e/Santa_Mar%C3%ADa_Catedral_-_Chiclayo.jpg/500px-Santa_Mar%C3%ADa_Catedral_-_Chiclayo.jpg'
+    );
+  });
+
   test('proxyMedia() forwards save failures', async () => {
     utils.saveFile = jest.fn(async () => ({ success: false, reason: 'SAVEFILE_ERROR' }));
     await expect(utils.proxyMedia({
@@ -211,6 +235,49 @@ describe('Utils factory', () => {
       cookies: {},
       params: {},
     })).resolves.toEqual({ success: false, reason: 'SAVEFILE_ERROR' });
+  });
+
+  test('saveFile() retries and replaces zero-byte cached media files', async () => {
+    const filePath = '/__test__/Santa_Mar%C3%ADa_Catedral.jpg';
+    const savedPath = path.join(__dirname, '../media/__test__/Santa_María_Catedral.jpg');
+    await fs.mkdir(path.dirname(savedPath), { recursive: true });
+    await fs.writeFile(savedPath, '');
+
+    const result = await utils.saveFile(
+      new URL('https://upload.wikimedia.org/__test__/Santa_Mar%C3%ADa_Catedral.jpg'),
+      filePath
+    );
+
+    expect(result).toEqual({ success: true, path: savedPath });
+    expect(mockGotStream).toHaveBeenCalledWith(
+      new URL('https://upload.wikimedia.org/__test__/Santa_Mar%C3%ADa_Catedral.jpg'),
+      { headers: { 'User-Agent': 'test-agent' } }
+    );
+    await expect(fs.readFile(savedPath, 'utf8')).resolves.toBe('image-bytes');
+    await expect(fs.stat(`${savedPath}.download`)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  test('saveFile() removes incomplete temp files when downloads fail', async () => {
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    mockGotStream = jest.fn(() => {
+      const stream = new Readable({
+        read() {
+          this.destroy(new Error('download failed'));
+        },
+      });
+      return stream;
+    });
+    const filePath = '/__test__/broken.jpg';
+    const savedPath = path.join(__dirname, '../media/__test__/broken.jpg');
+
+    await expect(utils.saveFile(
+      new URL('https://upload.wikimedia.org/__test__/broken.jpg'),
+      filePath
+    )).resolves.toEqual({ success: false, reason: 'SAVEFILE_ERROR' });
+
+    await expect(fs.stat(savedPath)).rejects.toMatchObject({ code: 'ENOENT' });
+    await expect(fs.stat(`${savedPath}.download`)).rejects.toMatchObject({ code: 'ENOENT' });
+    logSpy.mockRestore();
   });
 
   test('customLogos() returns localized logo paths only for valid languages', () => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -10,6 +10,47 @@ module.exports = function(redis, gotClient = null) {
 
   let _got = gotClient;
 
+  function pathInside(parent, child) {
+    const relative = path.relative(parent, child)
+    return relative === '' || (relative && !relative.startsWith('..') && !path.isAbsolute(relative))
+  }
+
+  function mediaRootForUrl(url) {
+    if(url.hostname === 'maps.wikimedia.org') {
+      return path.resolve(__dirname, '../media/maps_wikimedia_org')
+    }
+    if(url.hostname === 'wikimedia.org' && url.pathname.startsWith('/api/')) {
+      return path.resolve(__dirname, '../media/api')
+    }
+    return path.resolve(__dirname, '../media')
+  }
+
+  function resolveMediaPath(mediaRoot, filePath) {
+    const decodedPath = decodeURIComponent(filePath)
+    const relativePath = decodedPath.replace(/^[/\\]+/, '')
+    const resolvedPath = path.resolve(mediaRoot, relativePath)
+
+    if(!pathInside(mediaRoot, resolvedPath)) {
+      return null
+    }
+    return resolvedPath
+  }
+
+  this.validMediaUrl = (url) => {
+    if(url.protocol !== 'https:') {
+      return false
+    }
+    if(['upload.wikimedia.org', 'maps.wikimedia.org', 'wikimedia.org'].includes(url.hostname)) {
+      return true
+    }
+    const wikipediaSuffix = '.wikipedia.org'
+    if(url.hostname.endsWith(wikipediaSuffix)) {
+      const lang = url.hostname.slice(0, -wikipediaSuffix.length)
+      return this.validLang(lang)
+    }
+    return false
+  }
+
   this.download = async (url, params = '') => {
     if (!url) return { success: false, reason: 'MISSING_URL' };
 
@@ -261,16 +302,20 @@ module.exports = function(redis, gotClient = null) {
   }
 
   this.saveFile = async (url, file_path) => {
-    let media_path = ''
-    if(url.href.startsWith('https://maps.wikimedia.org/')) {
-      media_path = path.join(__dirname, '../media/maps_wikimedia_org')
-    } else if(url.href.startsWith('https://wikimedia.org/media/api/')) {
-      media_path = path.join(__dirname, '../media/api')
-    } else {
-      media_path = path.join(__dirname, '../media')
+    if(!this.validMediaUrl(url)) {
+      return { success: false, reason: 'INVALID_MEDIA_URL' }
     }
 
-    const path_with_filename = decodeURI(`${media_path}${file_path}`)
+    const media_path = mediaRootForUrl(url)
+    let path_with_filename
+    try {
+      path_with_filename = resolveMediaPath(media_path, file_path)
+    } catch(err) {
+      return { success: false, reason: 'INVALID_MEDIA_PATH' }
+    }
+    if(!path_with_filename) {
+      return { success: false, reason: 'INVALID_MEDIA_PATH' }
+    }
     const path_without_filename = path.dirname(path_with_filename)
     const temp_path = `${path_with_filename}.download`
     const options = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,14 +1,14 @@
-module.exports = function(redis) {
+module.exports = function(redis, gotClient = null) {
   const config = require('../wikiless.config')
   const parser = require('node-html-parser')
   const fs = require('fs').promises
-  const { createWriteStream, existsSync } = require('fs')
+  const { createWriteStream } = require('fs')
   const path = require('path')
   const stream = require('stream')
   const { promisify } = require('util')
   const pipeline = promisify(stream.pipeline)
 
-  let _got;
+  let _got = gotClient;
 
   this.download = async (url, params = '') => {
     if (!url) return { success: false, reason: 'MISSING_URL' };
@@ -261,11 +261,6 @@ module.exports = function(redis) {
   }
 
   this.saveFile = async (url, file_path) => {
-    if (!_got) {
-      const mod = await import('got');
-      _got = mod.default;
-    }
-
     let media_path = ''
     if(url.href.startsWith('https://maps.wikimedia.org/')) {
       media_path = path.join(__dirname, '../media/maps_wikimedia_org')
@@ -277,26 +272,50 @@ module.exports = function(redis) {
 
     const path_with_filename = decodeURI(`${media_path}${file_path}`)
     const path_without_filename = path.dirname(path_with_filename)
+    const temp_path = `${path_with_filename}.download`
     const options = {
       headers: { 'User-Agent': config.wikimedia_useragent }
     }
 
-    if(!existsSync(path_with_filename)) {
-      try {
-        await fs.mkdir(path_without_filename, { recursive: true })
-      } catch(err) {
-        return { success: false, reason: 'MKDIR_FAILED' }
+    try {
+      const stats = await fs.stat(path_with_filename)
+      if(stats.size > 0) {
+        return { success: true, path: path_with_filename }
       }
+      await fs.unlink(path_with_filename)
+    } catch(err) {
+      if(err.code !== 'ENOENT') {
+        return { success: false, reason: 'STAT_FAILED' }
+      }
+    }
 
-      try {
-        await pipeline(
-          _got.stream(url, options),
-          createWriteStream(path_with_filename)
-        )
-      } catch(err) {
-        console.log(`Error while saving ${path_with_filename}. Details:${err}`)
-        return { success: false, reason: 'SAVEFILE_ERROR' }
+    if (!_got) {
+      const mod = await import('got');
+      _got = mod.default;
+    }
+
+    try {
+      await fs.mkdir(path_without_filename, { recursive: true })
+    } catch(err) {
+      return { success: false, reason: 'MKDIR_FAILED' }
+    }
+
+    try {
+      await fs.rm(temp_path, { force: true })
+      await pipeline(
+        _got.stream(url, options),
+        createWriteStream(temp_path)
+      )
+      const stats = await fs.stat(temp_path)
+      if(stats.size === 0) {
+        await fs.rm(temp_path, { force: true })
+        return { success: false, reason: 'SAVEFILE_EMPTY' }
       }
+      await fs.rename(temp_path, path_with_filename)
+    } catch(err) {
+      await fs.rm(temp_path, { force: true }).catch(() => {})
+      console.log(`Error while saving ${path_with_filename}. Details:${err}`)
+      return { success: false, reason: 'SAVEFILE_ERROR' }
     }
 
     return { success: true, path: path_with_filename }

--- a/src/utils.js
+++ b/src/utils.js
@@ -20,6 +20,20 @@ module.exports = function(redis, gotClient = null) {
     return path.resolve(__dirname, '../media')
   }
 
+  function mediaFetchUrlForUrl(url, mediaFilePath) {
+    if(url.hostname === 'maps.wikimedia.org') {
+      return `https://maps.wikimedia.org${mediaFilePath.urlPath}`
+    }
+    if(url.hostname === 'wikimedia.org') {
+      return `https://wikimedia.org/api${mediaFilePath.urlPath}`
+    }
+    if(url.hostname.endsWith('.wikipedia.org')) {
+      const lang = encodeURIComponent(url.hostname.slice(0, -'.wikipedia.org'.length))
+      return `https://${lang}.wikipedia.org${mediaFilePath.urlPath.replace(/^\/api\/[^/]+/, '')}`
+    }
+    return `https://upload.wikimedia.org${mediaFilePath.urlPath}`
+  }
+
   function normalizeMediaPathFromRequest(rawPath) {
     if(typeof rawPath !== 'string' || !rawPath.startsWith('/') || rawPath.includes('\0') || rawPath.includes('\\')) {
       return null
@@ -332,6 +346,7 @@ module.exports = function(redis, gotClient = null) {
     if(!mediaFilePath) {
       return { success: false, reason: 'INVALID_MEDIA_PATH' }
     }
+    const fetch_url = mediaFetchUrlForUrl(url, mediaFilePath)
 
     const relativePath = mediaFilePath.filePath.replace(/^[/\\]+/, '')
     const path_with_filename = path.resolve(media_path, relativePath)
@@ -371,7 +386,7 @@ module.exports = function(redis, gotClient = null) {
     try {
       await fs.rm(temp_path, { force: true })
       await pipeline(
-        _got.stream(url, options),
+        _got.stream(fetch_url, options),
         createWriteStream(temp_path)
       )
       const stats = await fs.stat(temp_path)

--- a/src/utils.js
+++ b/src/utils.js
@@ -10,11 +10,6 @@ module.exports = function(redis, gotClient = null) {
 
   let _got = gotClient;
 
-  function pathInside(parent, child) {
-    const relative = path.relative(parent, child)
-    return relative === '' || (relative && !relative.startsWith('..') && !path.isAbsolute(relative))
-  }
-
   function mediaRootForUrl(url) {
     if(url.hostname === 'maps.wikimedia.org') {
       return path.resolve(__dirname, '../media/maps_wikimedia_org')
@@ -25,15 +20,33 @@ module.exports = function(redis, gotClient = null) {
     return path.resolve(__dirname, '../media')
   }
 
-  function resolveMediaPath(mediaRoot, filePath) {
-    const decodedPath = decodeURIComponent(filePath)
-    const relativePath = decodedPath.replace(/^[/\\]+/, '')
-    const resolvedPath = path.resolve(mediaRoot, relativePath)
-
-    if(!pathInside(mediaRoot, resolvedPath)) {
+  function normalizeMediaPathFromRequest(rawPath) {
+    if(typeof rawPath !== 'string' || !rawPath.startsWith('/') || rawPath.includes('\0') || rawPath.includes('\\')) {
       return null
     }
-    return resolvedPath
+
+    const decodedSegments = []
+    const encodedSegments = []
+    const segments = rawPath.split('/').slice(1)
+    for(let i = 0; i < segments.length; i++) {
+      let decoded
+      try {
+        decoded = decodeURIComponent(segments[i])
+      } catch(err) {
+        return null
+      }
+
+      if(!decoded || decoded === '.' || decoded === '..' || decoded.includes('/') || decoded.includes('\\') || decoded.includes('\0')) {
+        return null
+      }
+      decodedSegments.push(decoded)
+      encodedSegments.push(encodeURIComponent(decoded))
+    }
+
+    return {
+      filePath: `/${decodedSegments.join('/')}`,
+      urlPath: `/${encodedSegments.join('/')}`
+    }
   }
 
   this.validMediaUrl = (url) => {
@@ -273,24 +286,32 @@ module.exports = function(redis, gotClient = null) {
     let wikimedia_path = ''
     switch (wiki_domain) {
       case 'maps.wikimedia.org':
-        path = req.url.split('/media/maps_wikimedia_org')[1]
+        path = normalizeMediaPathFromRequest(req.url.split('/media/maps_wikimedia_org')[1])
+        if(!path) return { success: false, reason: 'INVALID_MEDIA_PATH' }
         domain = 'maps.wikimedia.org'
-        wikimedia_path = path
+        wikimedia_path = path.urlPath
+        path = path.filePath
         break;
       case '/api/rest_v1/page/pdf':
         const lang = req.query.lang || req.cookies.default_lang || config.default_lang
+        const pdfPath = normalizeMediaPathFromRequest(`/api/${lang}${wiki_domain}/${req.params.page}`)
+        if(!pdfPath) return { success: false, reason: 'INVALID_MEDIA_PATH' }
         domain = `${lang}.wikipedia.org`
-        wikimedia_path = `/api/rest_v1/page/pdf/${req.params.page}`
-        path = `/api/${lang}${wiki_domain}/${req.params.page}`
+        wikimedia_path = `/api/rest_v1/page/pdf/${encodeURIComponent(req.params.page)}`
+        path = pdfPath.filePath
         break;
       case 'wikimedia.org/api/rest_v1/media':
+        path = normalizeMediaPathFromRequest(req.url.split('/media/api')[1])
+        if(!path) return { success: false, reason: 'INVALID_MEDIA_PATH' }
         domain = 'wikimedia.org'
-        wikimedia_path = req.url.replace('/media/api/rest_v1', '/api/rest_v1')
-        path = req.url.split('/media/api')[1]
+        wikimedia_path = `/api${path.urlPath}`
+        path = path.filePath
         break;
       default:
-        path = req.url.split('/media')[1]
-        wikimedia_path = path + params
+        path = normalizeMediaPathFromRequest(req.url.split('/media')[1])
+        if(!path) return { success: false, reason: 'INVALID_MEDIA_PATH' }
+        wikimedia_path = path.urlPath + params
+        path = path.filePath
     }
     const url = new URL(`https://${domain}${wikimedia_path}`)
     const file = await this.saveFile(url, path)
@@ -307,13 +328,15 @@ module.exports = function(redis, gotClient = null) {
     }
 
     const media_path = mediaRootForUrl(url)
-    let path_with_filename
-    try {
-      path_with_filename = resolveMediaPath(media_path, file_path)
-    } catch(err) {
+    const mediaFilePath = normalizeMediaPathFromRequest(file_path)
+    if(!mediaFilePath) {
       return { success: false, reason: 'INVALID_MEDIA_PATH' }
     }
-    if(!path_with_filename) {
+
+    const relativePath = mediaFilePath.filePath.replace(/^[/\\]+/, '')
+    const path_with_filename = path.resolve(media_path, relativePath)
+    const relative = path.relative(media_path, path_with_filename)
+    if(relative === '..' || relative.startsWith('..' + path.sep) || path.isAbsolute(relative)) {
       return { success: false, reason: 'INVALID_MEDIA_PATH' }
     }
     const path_without_filename = path.dirname(path_with_filename)


### PR DESCRIPTION
Inject got client for testing and harden saveFile behavior. utils now accepts an optional gotClient, and saveFile: checks for existing non-zero cached files, removes zero-byte stale files, writes to a .download temp file, validates size, renames on success, and cleans up temp files on failure. Tests were updated to mock streaming, add cases for encoded Wikimedia thumbnail paths, retrying zero-byte cached media, and ensuring incomplete temp files are removed; test teardown now cleans the media test directory. Also removed existsSync usage in favor of fs.stat and added better error handling and logging.