### PR TITLE
fix: Map media proxy errors to proper HTTP statuses

### DIFF
--- a/__tests__/routes.test.js
+++ b/__tests__/routes.test.js
@@ -29,6 +29,12 @@ const routes = require('../src/routes');
 let app;
 beforeEach(() => {
   jest.clearAllMocks();
+  utils.handleWikiPage.mockImplementation((req, res, prefix) => res.status(200).send(`HANDLED_${prefix}`));
+  utils.proxyMedia.mockImplementation(async () => ({ success: true, path: 'DUMMY_PATH' }));
+  utils.preferencesPage.mockImplementation(() => '<html>PREFERENCES</html>');
+  utils.customLogos.mockImplementation(() => false);
+  utils.wikilessLogo.mockImplementation(() => 'LOGO_PATH');
+  utils.wikilessFavicon.mockImplementation(() => 'FAVICON_PATH');
   app = express();
   app.use(cookieParser());
   app.use(bodyParser.urlencoded({ extended: true }));
@@ -109,10 +115,22 @@ describe('Routes wiring', () => {
     expect(utils.proxyMedia).toHaveBeenCalledWith(expect.any(Object), 'wikimedia.org/api/rest_v1/media');
   });
 
-  it('GET /media/* returns 404 when proxying fails', async () => {
+  it('GET /media/* returns 502 when upstream fetching fails', async () => {
     utils.proxyMedia.mockResolvedValueOnce({ success: false, reason: 'SAVEFILE_ERROR' });
     const res = await request(app).get('/media/missing.png');
+    expect(res.status).toBe(502);
+  });
+
+  it('GET /media/* returns 404 for invalid media paths', async () => {
+    utils.proxyMedia.mockResolvedValueOnce({ success: false, reason: 'INVALID_MEDIA_PATH' });
+    const res = await request(app).get('/media/invalid.png');
     expect(res.status).toBe(404);
+  });
+
+  it('GET /media/* returns 500 for local cache filesystem failures', async () => {
+    utils.proxyMedia.mockResolvedValueOnce({ success: false, reason: 'MKDIR_FAILED' });
+    const res = await request(app).get('/media/file.png');
+    expect(res.status).toBe(500);
   });
 
   it('GET /w/index.php?search=Foo&lang=de -> redirect', async () => {
@@ -205,10 +223,10 @@ describe('Routes wiring', () => {
     expect(utils.proxyMedia).toHaveBeenCalledWith(expect.any(Object), '/api/rest_v1/page/pdf');
   });
 
-  it('GET /api/rest_v1/page/pdf/:page returns 404 when proxying fails', async () => {
+  it('GET /api/rest_v1/page/pdf/:page returns 502 when proxy fetching fails', async () => {
     utils.proxyMedia.mockResolvedValueOnce({ success: false, reason: 'SAVEFILE_ERROR' });
     const res = await request(app).get('/api/rest_v1/page/pdf/Foo');
-    expect(res.status).toBe(404);
+    expect(res.status).toBe(502);
   });
 
   it('GET /zh* redirects Chinese variants to wiki pages', async () => {

--- a/src/routes.js
+++ b/src/routes.js
@@ -60,7 +60,7 @@ module.exports = (app, utils) => {
 
         return res.sendFile(media.path)
       }
-      return res.sendStatus(404)
+      return res.sendStatus(mediaFailureStatus(media.reason))
     }
 
     if(req.url.startsWith('/static/images/project-logos/') || req.url === '/static/images/mobile/copyright/wikipedia.png' || req.url === '/static/apple-touch/wikipedia.png') {
@@ -92,6 +92,21 @@ module.exports = (app, utils) => {
 
     return next()
   })
+
+  function mediaFailureStatus(reason) {
+    switch (reason) {
+      case 'INVALID_MEDIA_PATH':
+      case 'INVALID_MEDIA_URL':
+        return 404
+      case 'MKDIR_FAILED':
+      case 'STAT_FAILED':
+        return 500
+      case 'SAVEFILE_EMPTY':
+      case 'SAVEFILE_ERROR':
+      default:
+        return 502
+    }
+  }
 
   function md5HashParts(fileName) {
     const normalized = fileName.replace(/ /g, '_')
@@ -159,7 +174,7 @@ module.exports = (app, utils) => {
       let filename = `${req.params.page}.pdf`
       return res.download(media.path, filename)
     }
-    return res.sendStatus(404)
+    return res.sendStatus(mediaFailureStatus(media.reason))
   })
 
   // handle chinese variants


### PR DESCRIPTION
Introduce mediaFailureStatus(reason) in routes to map proxy failure reasons to appropriate HTTP codes (INVALID_MEDIA_* -> 404, MKDIR_FAILED/STAT_FAILED -> 500, SAVEFILE_* and others -> 502) and replace hardcoded 404 responses for media endpoints. Update tests to add common utils mocks in beforeEach and adjust/extend media proxy tests: expect 502 for upstream save errors, 404 for invalid media paths, and 500 for local cache filesystem failures; also update PDF proxy test to expect 502 when proxying fails.