### PR TITLE
fix: Preserve media query params and headers

### DIFF
--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -27,6 +27,7 @@ describe('Utils factory', () => {
 
   afterEach(async () => {
     await fs.rm(path.join(__dirname, '../media/__test__'), { recursive: true, force: true });
+    await fs.rm(path.join(__dirname, '../media/maps_wikimedia_org/__test__'), { recursive: true, force: true });
     await fs.rm(path.join(__dirname, '../media/api/fr/api/rest_v1/page/pdf/Foo'), { force: true });
   });
 
@@ -183,8 +184,13 @@ describe('Utils factory', () => {
     });
 
     await utils.proxyMedia({
-      url: '/media/maps_wikimedia_org/osm-intl/a.png',
-      query: {},
+      url: '/media/maps_wikimedia_org/img/osm-intl,10,a,a,270x200@2x.png?lang=en&domain=en.wikipedia.org&title=Wedding_of_Prince_William_and_Catherine_Middleton&revid=1355840665',
+      query: {
+        lang: 'en',
+        domain: 'en.wikipedia.org',
+        title: 'Wedding_of_Prince_William_and_Catherine_Middleton',
+        revid: '1355840665',
+      },
       cookies: {},
       params: {},
     }, 'maps.wikimedia.org');
@@ -203,12 +209,15 @@ describe('Utils factory', () => {
       params: { page: 'Foo' },
     }, '/api/rest_v1/page/pdf');
 
-    expect(utils.saveFile.mock.calls[1][0].href).toBe('https://maps.wikimedia.org/osm-intl/a.png');
-    expect(utils.saveFile.mock.calls[1][1]).toBe('/osm-intl/a.png');
+    expect(utils.saveFile.mock.calls[1][0].href).toBe('https://maps.wikimedia.org/img/osm-intl,10,a,a,270x200@2x.png?lang=en&domain=en.wikipedia.org&title=Wedding_of_Prince_William_and_Catherine_Middleton&revid=1355840665');
+    expect(utils.saveFile.mock.calls[1][1]).toBe('/img/osm-intl,10,a,a,270x200@2x.png');
+    expect(utils.saveFile.mock.calls[1][2]).toEqual(expect.objectContaining({ url: expect.stringContaining('/media/maps_wikimedia_org/') }));
     expect(utils.saveFile.mock.calls[2][0].href).toBe('https://wikimedia.org/api/rest_v1/media/math/render/svg/abc');
     expect(utils.saveFile.mock.calls[2][1]).toBe('/rest_v1/media/math/render/svg/abc');
+    expect(utils.saveFile.mock.calls[2][2]).toEqual(expect.objectContaining({ url: '/media/api/rest_v1/media/math/render/svg/abc' }));
     expect(utils.saveFile.mock.calls[3][0].href).toBe('https://fr.wikipedia.org/api/rest_v1/page/pdf/Foo');
     expect(utils.saveFile.mock.calls[3][1]).toBe('/api/fr/api/rest_v1/page/pdf/Foo');
+    expect(utils.saveFile.mock.calls[3][2]).toEqual(expect.objectContaining({ url: '/api/rest_v1/page/pdf/Foo' }));
   });
 
   test('proxyMedia() preserves encoded Wikimedia thumbnail paths', async () => {
@@ -224,7 +233,8 @@ describe('Utils factory', () => {
 
     expect(utils.saveFile).toHaveBeenCalledWith(
       new URL('https://upload.wikimedia.org/wikipedia/commons/thumb/9/9e/Santa_Mar%C3%ADa_Catedral_-_Chiclayo.jpg/500px-Santa_Mar%C3%ADa_Catedral_-_Chiclayo.jpg'),
-      '/wikipedia/commons/thumb/9/9e/Santa_María_Catedral_-_Chiclayo.jpg/500px-Santa_María_Catedral_-_Chiclayo.jpg'
+      '/wikipedia/commons/thumb/9/9e/Santa_María_Catedral_-_Chiclayo.jpg/500px-Santa_María_Catedral_-_Chiclayo.jpg',
+      expect.objectContaining({ url: encodedPath })
     );
   });
 
@@ -262,7 +272,13 @@ describe('Utils factory', () => {
     expect(result).toEqual({ success: true, path: savedPath });
     expect(mockGotStream).toHaveBeenCalledWith(
       'https://upload.wikimedia.org/__test__/Santa_Mar%C3%ADa_Catedral.jpg',
-      { headers: { 'User-Agent': 'test-agent' } }
+      {
+        headers: {
+          'User-Agent': 'test-agent',
+          Referer: 'https://en.wikipedia.org/',
+          Origin: 'https://en.wikipedia.org',
+        },
+      }
     );
     await expect(fs.readFile(savedPath, 'utf8')).resolves.toBe('image-bytes');
     await expect(fs.stat(`${savedPath}.download`)).rejects.toMatchObject({ code: 'ENOENT' });
@@ -278,8 +294,60 @@ describe('Utils factory', () => {
 
     expect(mockGotStream).toHaveBeenCalledWith(
       'https://fr.wikipedia.org/api/rest_v1/page/pdf/Foo',
-      { headers: { 'User-Agent': 'test-agent' } }
+      {
+        headers: {
+          'User-Agent': 'test-agent',
+          Referer: 'https://fr.wikipedia.org/wiki/Foo',
+          Origin: 'https://fr.wikipedia.org',
+        },
+      }
     );
+  });
+
+  test('saveFile() maps a Wikiless page referer back to Wikipedia for media requests', async () => {
+    await utils.saveFile(
+      new URL('https://upload.wikimedia.org/__test__/from-page.jpg'),
+      '/__test__/from-page.jpg',
+      {
+        url: '/media/__test__/from-page.jpg',
+        query: {},
+        cookies: {},
+        headers: {
+          referer: 'https://test.example.org/wiki/École?lang=fr&oldid=123',
+        },
+      }
+    );
+
+    expect(mockGotStream).toHaveBeenCalledWith(
+      'https://upload.wikimedia.org/__test__/from-page.jpg',
+      {
+        headers: {
+          'User-Agent': 'test-agent',
+          Referer: 'https://fr.wikipedia.org/wiki/%C3%89cole?oldid=123',
+          Origin: 'https://fr.wikipedia.org',
+        },
+      }
+    );
+  });
+
+  test('saveFile() preserves map query parameters and sends Wikimedia context headers', async () => {
+    const result = await utils.saveFile(
+      new URL('https://maps.wikimedia.org/__test__/osm-intl,10,a,a,270x200@2x.png?lang=en&domain=en.wikipedia.org&title=Wedding_of_Prince_William_and_Catherine_Middleton&revid=1355840665'),
+      '/__test__/osm-intl,10,a,a,270x200@2x.png'
+    );
+
+    expect(mockGotStream).toHaveBeenCalledWith(
+      'https://maps.wikimedia.org/__test__/osm-intl,10,a,a,270x200@2x.png?lang=en&domain=en.wikipedia.org&title=Wedding_of_Prince_William_and_Catherine_Middleton&revid=1355840665',
+      {
+        headers: {
+          'User-Agent': 'test-agent',
+          Referer: 'https://en.wikipedia.org/wiki/Wedding_of_Prince_William_and_Catherine_Middleton?oldid=1355840665',
+          Origin: 'https://en.wikipedia.org',
+        },
+      }
+    );
+    expect(result.success).toBe(true);
+    expect(result.path).toMatch(/media\/maps_wikimedia_org\/__test__\/osm-intl,10,a,a,270x200@2x\.[0-9a-f]{16}\.png$/);
   });
 
   test('saveFile() rejects path traversal and malformed encoded paths', async () => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,6 +4,7 @@ module.exports = function(redis, gotClient = null) {
   const fs = require('fs').promises
   const { createWriteStream } = require('fs')
   const path = require('path')
+  const crypto = require('crypto')
   const stream = require('stream')
   const { promisify } = require('util')
   const pipeline = promisify(stream.pipeline)
@@ -21,20 +22,159 @@ module.exports = function(redis, gotClient = null) {
   }
 
   function mediaFetchUrlForUrl(url, mediaFilePath) {
+    const search = url.search || ''
     if(url.hostname === 'maps.wikimedia.org') {
-      return `https://maps.wikimedia.org${mediaFilePath.urlPath}`
+      return `https://maps.wikimedia.org${mediaFilePath.urlPath}${search}`
     }
     if(url.hostname === 'wikimedia.org') {
-      return `https://wikimedia.org/api${mediaFilePath.urlPath}`
+      return `https://wikimedia.org/api${mediaFilePath.urlPath}${search}`
     }
     if(url.hostname.endsWith('.wikipedia.org')) {
       const lang = encodeURIComponent(url.hostname.slice(0, -'.wikipedia.org'.length))
-      return `https://${lang}.wikipedia.org${mediaFilePath.urlPath.replace(/^\/api\/[^/]+/, '')}`
+      return `https://${lang}.wikipedia.org${mediaFilePath.urlPath.replace(/^\/api\/[^/]+/, '')}${search}`
     }
-    return `https://upload.wikimedia.org${mediaFilePath.urlPath}`
+    return `https://upload.wikimedia.org${mediaFilePath.urlPath}${search}`
   }
 
-  function normalizeMediaPathFromRequest(rawPath) {
+  function mediaCachePathForUrl(url, filePath) {
+    if(!url.search) {
+      return filePath
+    }
+
+    const queryHash = crypto.createHash('sha256').update(url.search).digest('hex').slice(0, 16)
+    const parsed = path.posix.parse(filePath)
+    const filename = `${parsed.name}.${queryHash}${parsed.ext}`
+    return path.posix.join(parsed.dir, filename)
+  }
+
+  function mediaRequestPath(req) {
+    try {
+      return new URL(req.url, 'https://wikiless.local').pathname
+    } catch(err) {
+      return req.url.split('?')[0]
+    }
+  }
+
+  function mediaRequestSearch(req) {
+    try {
+      return new URL(req.url, 'https://wikiless.local').search
+    } catch(err) {
+      const params = new URLSearchParams(req.query).toString()
+      return params ? `?${params}` : ''
+    }
+  }
+
+  function wikipediaContextFromMapsUrl(url) {
+    const domain = url.searchParams.get('domain')
+    const title = url.searchParams.get('title')
+    if(!domain || !title) {
+      return null
+    }
+
+    let domainUrl
+    try {
+      domainUrl = new URL(`https://${domain}`)
+    } catch(err) {
+      return null
+    }
+
+    const wikipediaSuffix = '.wikipedia.org'
+    if(!domainUrl.hostname.endsWith(wikipediaSuffix) || !this.validLang(domainUrl.hostname.slice(0, -wikipediaSuffix.length))) {
+      return null
+    }
+
+    const origin = `https://${domainUrl.hostname}`
+    const referer = new URL(`/wiki/${encodeURIComponent(title)}`, origin)
+    const revid = url.searchParams.get('revid')
+    if(revid && /^\d+$/.test(revid)) {
+      referer.searchParams.set('oldid', revid)
+    }
+
+    return { origin, referer: referer.href }
+  }
+
+  function wikipediaContextFromRequest(req) {
+    if(!req) {
+      return null
+    }
+
+    const refererHeader = req.headers?.referer || req.headers?.referrer
+    if(!refererHeader) {
+      return null
+    }
+
+    let referer
+    let wikilessOrigin
+    try {
+      wikilessOrigin = new URL(`${global.protocol || 'https://'}${config.domain}`)
+      referer = new URL(refererHeader, wikilessOrigin)
+    } catch(err) {
+      return null
+    }
+
+    if(referer.hostname !== wikilessOrigin.hostname || !referer.pathname.startsWith('/wiki/')) {
+      return null
+    }
+
+    let lang = referer.searchParams.get('lang') || req.query?.lang || req.cookies?.default_lang || config.default_lang
+    lang = this.mapToWikiSubdomain(lang)
+    if(!this.validLang(lang)) {
+      return null
+    }
+
+    const origin = `https://${lang}.wikipedia.org`
+    const wikipediaReferer = new URL(referer.pathname, origin)
+    const oldid = referer.searchParams.get('oldid')
+    if(oldid && /^\d+$/.test(oldid)) {
+      wikipediaReferer.searchParams.set('oldid', oldid)
+    }
+
+    return { origin, referer: wikipediaReferer.href }
+  }
+
+  function wikipediaContextFromTargetUrl(url) {
+    const wikipediaSuffix = '.wikipedia.org'
+    if(url.hostname.endsWith(wikipediaSuffix) && this.validLang(url.hostname.slice(0, -wikipediaSuffix.length))) {
+      const origin = `https://${url.hostname}`
+      const referer = new URL(url.pathname.replace(/^\/api\/rest_v1\/page\/pdf\//, '/wiki/'), origin)
+      return { origin, referer: referer.href }
+    }
+
+    const lang = this.mapToWikiSubdomain(config.default_lang)
+    if(this.validLang(lang)) {
+      const origin = `https://${lang}.wikipedia.org`
+      return { origin, referer: `${origin}/` }
+    }
+
+    return null
+  }
+
+  function mediaRequestHeaders(url, req = null) {
+    const headers = { 'User-Agent': config.wikimedia_useragent }
+    const context =
+      (url.hostname === 'maps.wikimedia.org' ? wikipediaContextFromMapsUrl.call(this, url) : null) ||
+      wikipediaContextFromRequest.call(this, req) ||
+      wikipediaContextFromTargetUrl.call(this, url)
+
+    if(context) {
+      headers.Referer = context.referer
+      headers.Origin = context.origin
+    }
+
+    return headers
+  }
+
+  function encodeMediaPathSegment(decoded) {
+    return encodeURIComponent(decoded)
+  }
+
+  function encodeMapPathSegment(decoded) {
+    return encodeURIComponent(decoded)
+      .replace(/%2C/gi, ',')
+      .replace(/%40/gi, '@')
+  }
+
+  function normalizeMediaPathFromRequest(rawPath, encodeSegment = encodeMediaPathSegment) {
     if(typeof rawPath !== 'string' || !rawPath.startsWith('/') || rawPath.includes('\0') || rawPath.includes('\\')) {
       return null
     }
@@ -54,7 +194,7 @@ module.exports = function(redis, gotClient = null) {
         return null
       }
       decodedSegments.push(decoded)
-      encodedSegments.push(encodeURIComponent(decoded))
+      encodedSegments.push(encodeSegment(decoded))
     }
 
     return {
@@ -289,10 +429,11 @@ module.exports = function(redis, gotClient = null) {
   }
 
   this.proxyMedia = async (req, wiki_domain='') => {
-    let params = new URLSearchParams(req.query).toString() || ''
-
-    if(params) {
-      params = '?' + params
+    const requestPath = mediaRequestPath(req)
+    let params = mediaRequestSearch(req)
+    if(!params) {
+      const queryParams = new URLSearchParams(req.query).toString()
+      params = queryParams ? `?${queryParams}` : ''
     }
 
     let path = ''
@@ -300,10 +441,10 @@ module.exports = function(redis, gotClient = null) {
     let wikimedia_path = ''
     switch (wiki_domain) {
       case 'maps.wikimedia.org':
-        path = normalizeMediaPathFromRequest(req.url.split('/media/maps_wikimedia_org')[1])
+        path = normalizeMediaPathFromRequest(requestPath.split('/media/maps_wikimedia_org')[1], encodeMapPathSegment)
         if(!path) return { success: false, reason: 'INVALID_MEDIA_PATH' }
         domain = 'maps.wikimedia.org'
-        wikimedia_path = path.urlPath
+        wikimedia_path = path.urlPath + params
         path = path.filePath
         break;
       case '/api/rest_v1/page/pdf':
@@ -315,20 +456,20 @@ module.exports = function(redis, gotClient = null) {
         path = pdfPath.filePath
         break;
       case 'wikimedia.org/api/rest_v1/media':
-        path = normalizeMediaPathFromRequest(req.url.split('/media/api')[1])
+        path = normalizeMediaPathFromRequest(requestPath.split('/media/api')[1])
         if(!path) return { success: false, reason: 'INVALID_MEDIA_PATH' }
         domain = 'wikimedia.org'
-        wikimedia_path = `/api${path.urlPath}`
+        wikimedia_path = `/api${path.urlPath}${params}`
         path = path.filePath
         break;
       default:
-        path = normalizeMediaPathFromRequest(req.url.split('/media')[1])
+        path = normalizeMediaPathFromRequest(requestPath.split('/media')[1])
         if(!path) return { success: false, reason: 'INVALID_MEDIA_PATH' }
         wikimedia_path = path.urlPath + params
         path = path.filePath
     }
     const url = new URL(`https://${domain}${wikimedia_path}`)
-    const file = await this.saveFile(url, path)
+    const file = await this.saveFile(url, path, req)
 
     if(file.success === true) {
       return { success: true, path: file.path }
@@ -336,19 +477,23 @@ module.exports = function(redis, gotClient = null) {
     return { success: false, reason: file.reason }
   }
 
-  this.saveFile = async (url, file_path) => {
+  this.saveFile = async (url, file_path, req = null) => {
     if(!this.validMediaUrl(url)) {
       return { success: false, reason: 'INVALID_MEDIA_URL' }
     }
 
     const media_path = mediaRootForUrl(url)
-    const mediaFilePath = normalizeMediaPathFromRequest(file_path)
-    if(!mediaFilePath) {
+    const fetchMediaFilePath = normalizeMediaPathFromRequest(
+      file_path,
+      url.hostname === 'maps.wikimedia.org' ? encodeMapPathSegment : encodeMediaPathSegment
+    )
+    const cacheMediaFilePath = normalizeMediaPathFromRequest(mediaCachePathForUrl(url, file_path))
+    if(!fetchMediaFilePath || !cacheMediaFilePath) {
       return { success: false, reason: 'INVALID_MEDIA_PATH' }
     }
-    const fetch_url = mediaFetchUrlForUrl(url, mediaFilePath)
+    const fetch_url = mediaFetchUrlForUrl(url, fetchMediaFilePath)
 
-    const relativePath = mediaFilePath.filePath.replace(/^[/\\]+/, '')
+    const relativePath = cacheMediaFilePath.filePath.replace(/^[/\\]+/, '')
     const path_with_filename = path.resolve(media_path, relativePath)
     const relative = path.relative(media_path, path_with_filename)
     if(relative === '..' || relative.startsWith('..' + path.sep) || path.isAbsolute(relative)) {
@@ -356,9 +501,7 @@ module.exports = function(redis, gotClient = null) {
     }
     const path_without_filename = path.dirname(path_with_filename)
     const temp_path = `${path_with_filename}.download`
-    const options = {
-      headers: { 'User-Agent': config.wikimedia_useragent }
-    }
+    const options = { headers: mediaRequestHeaders.call(this, url, req) }
 
     try {
       const stats = await fs.stat(path_with_filename)


### PR DESCRIPTION
Include media URL query strings when fetching from Wikimedia and maps, and send appropriate Referer/Origin headers. Add sha256-based cache suffixing for media files with query parameters to avoid collisions, plus helpers to derive request/search, Wikipedia context (from maps URLs or incoming referer), and to build media request headers. Also add map-specific path encoding, import crypto, and thread the original request through proxyMedia/saveFile. Update tests to cover map query params, referer mapping, and header behavior.