### PR TITLE
feat: Support outbound HTTP proxy and update repo links

### DIFF
--- a/Chinese.md
+++ b/Chinese.md
@@ -16,7 +16,7 @@
 
 运行 Wikiless 的步骤如下：
 ```
-https://github.com/Metastem/Wikiless/wiki
+https://github.com/tiekoetter/Wikiless/wiki
 ```
 
 
@@ -30,15 +30,15 @@ https://github.com/Metastem/Wikiless/wiki
 
 ## TODO
 
-- [x] - 修复点击缩略图后图片无法加载的问题 - [#161](https://github.com/Metastem/Wikiless/issues/161) 和 [#162](https://github.com/Metastem/Wikiless/pull/162)
-- [x] - 修复在设置为其他默认语言时，所有语言链接失效的问题 - [#161](https://github.com/Metastem/Wikiless/issues/161)
+- [x] - 修复点击缩略图后图片无法加载的问题 - [#161](https://github.com/tiekoetter/Wikiless/issues/161) 和 [#162](https://github.com/tiekoetter/Wikiless/pull/162)
+- [x] - 修复在设置为其他默认语言时，所有语言链接失效的问题 - [#161](https://github.com/tiekoetter/Wikiless/issues/161)
 - [x] - 已修复 [Code Scanning](https://github.com/V4NT-ORG/Wikiless-Reborn/security/code-scanning) 中的 10 个安全问题
 - [x] - 进一步加固 ```Dockerfile```
 - [x] - 修复了一些小 bug，并在 [```docker-compose.yml```](https://www.baeldung.com/ops/docker-memory-limit) 中添加了内存和 CPU 限制
-- [ ] - 支持其他维基百科样式 - [#25](https://github.com/Metastem/Wikiless/issues/25)
-- [ ] - 如果某个实例被封锁，则支持条件性跳转 - [#21](https://github.com/Metastem/Wikiless/issues/21)
+- [ ] - 支持其他维基百科样式 - [#25](https://github.com/tiekoetter/Wikiless/issues/25)
+- [ ] - 如果某个实例被封锁，则支持条件性跳转 - [#21](https://github.com/tiekoetter/Wikiless/issues/21)
 - [ ] - 修复 MediaWiki CSS 文件循环下载错误
-- [ ] - 修复搜索路由错误 - [#166](https://github.com/Metastem/Wikiless/issues/166)
+- [ ] - 修复搜索路由错误 - [#166](https://github.com/tiekoetter/Wikiless/issues/166)
 - [ ] - 增加不同语言版本，帮助用户在本国突破政府审查
 
 ## 许可证

--- a/Persian.md
+++ b/Persian.md
@@ -16,7 +16,7 @@
 
 برای اجرای Wikiless مراحل زیر را دنبال کنید:
 ```
-https://github.com/Metastem/Wikiless/wiki
+https://github.com/tiekoetter/Wikiless/wiki
 ```
 
 
@@ -30,15 +30,15 @@ https://github.com/Metastem/Wikiless/wiki
 
 ## TODO
 
-- [x] - رفع مشکل بارگذاری نشدن تصاویر پس از کلیک روی بندانگشتی‌ها - [#161](https://github.com/Metastem/Wikiless/issues/161) و [#162](https://github.com/Metastem/Wikiless/pull/162)  
-- [x] - رفع مشکل از کار افتادن همه پیوندهای زبانی هنگام تنظیم زبان پیش‌فرض دیگر - [#161](https://github.com/Metastem/Wikiless/issues/161)  
+- [x] - رفع مشکل بارگذاری نشدن تصاویر پس از کلیک روی بندانگشتی‌ها - [#161](https://github.com/tiekoetter/Wikiless/issues/161) و [#162](https://github.com/tiekoetter/Wikiless/pull/162)
+- [x] - رفع مشکل از کار افتادن همه پیوندهای زبانی هنگام تنظیم زبان پیش‌فرض دیگر - [#161](https://github.com/tiekoetter/Wikiless/issues/161)
 - [x] - برطرف شدن ۱۰ مشکل امنیتی در [Code Scanning](https://github.com/V4NT-ORG/Wikiless-Reborn/security/code-scanning)  
 - [x] - تقویت بیشتر ```Dockerfile```  
 - [x] - رفع چند باگ کوچک و افزودن محدودیت حافظه و CPU در [```docker-compose.yml```](https://www.baeldung.com/ops/docker-memory-limit)  
-- [ ] - پشتیبانی از سبک‌های مختلف ویکی‌پدیا - [#25](https://github.com/Metastem/Wikiless/issues/25)  
-- [ ] - پشتیبانی از پرش شرطی در صورت مسدود شدن یک نمونه - [#21](https://github.com/Metastem/Wikiless/issues/21)  
+- [ ] - پشتیبانی از سبک‌های مختلف ویکی‌پدیا - [#25](https://github.com/tiekoetter/Wikiless/issues/25)
+- [ ] - پشتیبانی از پرش شرطی در صورت مسدود شدن یک نمونه - [#21](https://github.com/tiekoetter/Wikiless/issues/21)
 - [ ] - رفع خطای بارگیری حلقه‌ای فایل‌های CSS مدیاویکی  
-- [ ] - رفع خطای مسیر جستجو - [#166](https://github.com/Metastem/Wikiless/issues/166)  
+- [ ] - رفع خطای مسیر جستجو - [#166](https://github.com/tiekoetter/Wikiless/issues/166)
 - [ ] - افزودن نسخه‌های زبانی مختلف برای کمک به کاربران در دور زدن سانسور دولتی  
 
 ## مجوز

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 To run Wikiless, follow these steps:
 
 ```
-https://github.com/Metastem/Wikiless/wiki
+https://github.com/tiekoetter/Wikiless/wiki
 ```
 
 # Usage

--- a/Russian.md
+++ b/Russian.md
@@ -17,7 +17,7 @@
 
 Чтобы запустить Wikiless, выполните следующие шаги:
 ```
-https://github.com/Metastem/Wikiless/wiki
+https://github.com/tiekoetter/Wikiless/wiki
 ```
 
 # Использование

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -2,12 +2,15 @@ jest.mock('../wikiless.config', () => ({
   default_lang: 'en',
   wikimedia_useragent: 'test-agent',
   domain: 'test.example.org',
+  http_proxy: '',
+  no_proxy: '',
   setexs: { wikipage: 3600 },
 }));
 
 const fs = require('fs').promises;
 const path = require('path');
 const { Readable } = require('stream');
+const config = require('../wikiless.config');
 const Utils = require('../src/utils.js');
 
 describe('Utils factory', () => {
@@ -22,6 +25,8 @@ describe('Utils factory', () => {
       connect: jest.fn().mockResolvedValue(),
     };
     utils = new Utils(fakeRedis, { stream: (...args) => mockGotStream(...args) });
+    config.http_proxy = '';
+    config.no_proxy = '';
     global.protocol = 'https://';
   });
 
@@ -45,6 +50,36 @@ describe('Utils factory', () => {
   test('download(): missing URL returns proper error', async () => {
     const result = await utils.download('');
     expect(result).toEqual({ success: false, reason: 'MISSING_URL' });
+  });
+
+  test('download() uses configured outbound HTTP proxy', async () => {
+    config.http_proxy = 'http://proxy.example:3128';
+    const gotClient = jest.fn(async () => ({ body: '<html></html>' }));
+    utils = new Utils(fakeRedis, gotClient);
+
+    const result = await utils.download('https://en.wikipedia.org/wiki/Foo');
+
+    expect(result.success).toBe(true);
+    expect(gotClient).toHaveBeenCalledWith(
+      'https://en.wikipedia.org/wiki/Foo?useskin=vector',
+      expect.objectContaining({
+        agent: expect.objectContaining({
+          http: expect.any(Object),
+          https: expect.any(Object),
+        }),
+      })
+    );
+  });
+
+  test('download() honors NO_PROXY for matching hosts', async () => {
+    config.http_proxy = 'http://proxy.example:3128';
+    config.no_proxy = '.wikipedia.org';
+    const gotClient = jest.fn(async () => ({ body: '<html></html>' }));
+    utils = new Utils(fakeRedis, gotClient);
+
+    await utils.download('https://en.wikipedia.org/wiki/Foo');
+
+    expect(gotClient.mock.calls[0][1]).not.toHaveProperty('agent');
   });
 
   test('validHtml() recognizes real HTML', () => {
@@ -301,6 +336,24 @@ describe('Utils factory', () => {
           Origin: 'https://fr.wikipedia.org',
         },
       }
+    );
+  });
+
+  test('saveFile() uses configured outbound HTTP proxy for media requests', async () => {
+    config.http_proxy = 'http://proxy.example:3128';
+    await utils.saveFile(
+      new URL('https://upload.wikimedia.org/__test__/proxied.jpg'),
+      '/__test__/proxied.jpg'
+    );
+
+    expect(mockGotStream).toHaveBeenCalledWith(
+      'https://upload.wikimedia.org/__test__/proxied.jpg',
+      expect.objectContaining({
+        agent: expect.objectContaining({
+          http: expect.any(Object),
+          https: expect.any(Object),
+        }),
+      })
     );
   });
 

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -52,6 +52,24 @@ describe('Utils factory', () => {
     expect(result).toEqual({ success: false, reason: 'MISSING_URL' });
   });
 
+  test.each([
+    'http://en.wikipedia.org/wiki/Foo',
+    'https://example.org/wiki/Foo',
+    'https://not-a-lang.wikipedia.org/wiki/Foo',
+    'https://en.wikipedia.org.evil.test/wiki/Foo',
+    'https://en.wikipedia.org/api/rest_v1/page/pdf/Foo',
+    'not a url',
+  ])('download() rejects non-Wikipedia page URL %s before fetching', async (downloadUrl) => {
+    const gotClient = jest.fn(async () => ({ body: '<html></html>' }));
+    utils = new Utils(fakeRedis, gotClient);
+
+    const result = await utils.download(downloadUrl);
+
+    expect(result).toEqual({ success: false, reason: 'INVALID_URL' });
+    expect(gotClient).not.toHaveBeenCalled();
+    expect(fakeRedis.connect).not.toHaveBeenCalled();
+  });
+
   test('download() uses configured outbound HTTP proxy', async () => {
     config.http_proxy = 'http://proxy.example:3128';
     const gotClient = jest.fn(async () => ({ body: '<html></html>' }));

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       REDIS_URL: redis://wikiless_redis:6379
       DEFAULT_LANG: ${DEFAULT_LANG:-en}
       THEME: ${THEME:-dark}
+      WIKILESS_HTTP_PROXY: ${WIKILESS_HTTP_PROXY:-}
+      WIKILESS_NO_PROXY: ${WIKILESS_NO_PROXY:-}
     ports:
       - "127.0.0.1:8180:8080" # change port if needed
     security_opt:

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
         "cookie-parser": "^1.4.7",
         "express": "^5.2.1",
         "got": "^15.0.5",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
         "node-html-parser": "^7.1.0",
         "redis": "^6.0.0"
       },
@@ -1503,6 +1505,15 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -3169,6 +3180,42 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/http2-wrapper": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
@@ -3181,6 +3228,42 @@
       "engines": {
         "node": ">=10.19.0"
       }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/human-signals": {
       "version": "2.1.0",
@@ -6920,6 +7003,11 @@
       "dev": true,
       "optional": true
     },
+    "agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="
+    },
     "ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -8072,6 +8160,30 @@
         "toidentifier": "~1.0.1"
       }
     },
+    "http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "requires": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+          "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
+      }
+    },
     "http2-wrapper": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
@@ -8079,6 +8191,30 @@
       "requires": {
         "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.2.0"
+      }
+    },
+    "https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "requires": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+          "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
       }
     },
     "human-signals": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "cookie-parser": "^1.4.7",
     "express": "^5.2.1",
     "got": "^15.0.5",
+    "http-proxy-agent": "^7.0.2",
+    "https-proxy-agent": "^7.0.6",
     "node-html-parser": "^7.1.0",
     "redis": "^6.0.0"
   },
@@ -23,7 +25,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Metastem/wikiless"
+    "url": "https://github.com/tiekoetter/Wikiless"
   },
   "license": "APGL-3.0"
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -210,6 +210,24 @@ module.exports = function(redis, gotClient = null) {
     }
   }
 
+  function wikipediaDownloadLang(url) {
+    const wikipediaSuffix = '.wikipedia.org'
+    if(url.protocol !== 'https:' || !url.hostname.endsWith(wikipediaSuffix)) {
+      return null
+    }
+
+    const lang = url.hostname.slice(0, -wikipediaSuffix.length)
+    if(!this.validLang(lang)) {
+      return null
+    }
+
+    if(url.pathname !== '/' && !url.pathname.startsWith('/wiki/') && !url.pathname.startsWith('/w/')) {
+      return null
+    }
+
+    return lang
+  }
+
   function encodeMediaPathSegment(decoded) {
     return encodeURIComponent(decoded)
   }
@@ -277,7 +295,18 @@ module.exports = function(redis, gotClient = null) {
       if (wikipage) url = url.replace(wikipage, encodeURIComponent(wikipage));
     }
   
-    const u = new URL(url);
+    let u
+    try {
+      u = new URL(url);
+    } catch (err) {
+      return { success: false, reason: 'INVALID_URL' };
+    }
+
+    const downloadLang = wikipediaDownloadLang.call(this, u)
+    if(!downloadLang) {
+      return { success: false, reason: 'INVALID_URL' };
+    }
+
     if (params) {
       params.split('&').forEach(p => {
         const [k, v] = p.split('=');
@@ -285,7 +314,7 @@ module.exports = function(redis, gotClient = null) {
       });
     }
     u.searchParams.set('useskin', 'vector');
-    url = u.toString();
+    url = `https://${downloadLang}.wikipedia.org${u.pathname}${u.search}`;
   
     const UA = config.wikimedia_useragent;
   

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,6 +3,8 @@ module.exports = function(redis, gotClient = null) {
   const parser = require('node-html-parser')
   const fs = require('fs').promises
   const { createWriteStream } = require('fs')
+  const { HttpProxyAgent } = require('http-proxy-agent')
+  const { HttpsProxyAgent } = require('https-proxy-agent')
   const path = require('path')
   const crypto = require('crypto')
   const stream = require('stream')
@@ -164,6 +166,50 @@ module.exports = function(redis, gotClient = null) {
     return headers
   }
 
+  function noProxyMatches(url) {
+    const noProxy = config.no_proxy
+    if(!noProxy) {
+      return false
+    }
+
+    const host = url.hostname.toLowerCase()
+    const hostWithPort = `${host}:${url.port || (url.protocol === 'https:' ? '443' : '80')}`
+    return noProxy.split(',').some((entry) => {
+      entry = entry.trim().toLowerCase()
+      if(!entry) {
+        return false
+      }
+      if(entry === '*') {
+        return true
+      }
+      if(entry === host || entry === hostWithPort) {
+        return true
+      }
+      if(entry.startsWith('*.')) {
+        return host.endsWith(entry.slice(1))
+      }
+      if(entry.startsWith('.')) {
+        return host === entry.slice(1) || host.endsWith(entry)
+      }
+      return false
+    })
+  }
+
+  function gotOptionsForUrl(url, options) {
+    if(!config.http_proxy || noProxyMatches(url)) {
+      return options
+    }
+
+    return {
+      ...options,
+      agent: {
+        http: new HttpProxyAgent(config.http_proxy),
+        https: new HttpsProxyAgent(config.http_proxy),
+        ...(options.agent || {})
+      }
+    }
+  }
+
   function encodeMediaPathSegment(decoded) {
     return encodeURIComponent(decoded)
   }
@@ -255,10 +301,10 @@ module.exports = function(redis, gotClient = null) {
     }
   
     try {
-      const { body } = await _got(url, {
+      const { body } = await _got(url, gotOptionsForUrl(u, {
         headers: { 'User-Agent': UA },
         timeout: { request: 10000 }
-      });
+      }));
       console.log(`Fetched ${url} from Wikipedia.`);
       return { success: true, html: body, processed: false, url };
     } catch (err) {
@@ -501,7 +547,7 @@ module.exports = function(redis, gotClient = null) {
     }
     const path_without_filename = path.dirname(path_with_filename)
     const temp_path = `${path_with_filename}.download`
-    const options = { headers: mediaRequestHeaders.call(this, url, req) }
+    const options = gotOptionsForUrl(url, { headers: mediaRequestHeaders.call(this, url, req) })
 
     try {
       const stats = await fs.stat(path_with_filename)

--- a/wikiless.config
+++ b/wikiless.config
@@ -42,6 +42,14 @@ const config = {
   wikimedia_useragent: process.env.wikimedia_useragent || 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36',
 
   /**
+  * Optional outbound HTTP proxy for requests Wikiless makes to Wikimedia.
+  * Example: WIKILESS_HTTP_PROXY=http://proxy.example:3128
+  * Falls back to standard proxy environment variables if set.
+  */
+  http_proxy: process.env.WIKILESS_HTTP_PROXY || process.env.HTTPS_PROXY || process.env.https_proxy || process.env.HTTP_PROXY || process.env.http_proxy || process.env.ALL_PROXY || process.env.all_proxy || '',
+  no_proxy: process.env.WIKILESS_NO_PROXY || process.env.NO_PROXY || process.env.no_proxy || '',
+
+  /**
   * Cache control. Wikiless can automatically remove the cached media files from
   * the server. Cache control is on by default.
   * 'cache_control_interval' sets the interval for often the cache directory


### PR DESCRIPTION
Add optional outbound HTTP proxy support for Wikimedia requests. Introduce WIKILESS_HTTP_PROXY and WIKILESS_NO_PROXY env vars (docker-compose), expose http_proxy/no_proxy in wikiless.config, and integrate http-proxy-agent / https-proxy-agent in src/utils.js with noProxyMatches and gotOptionsForUrl to apply proxy agents for downloads and media saves. Update package.json to depend on the proxy agents (and update lockfile). Add unit tests covering proxy usage and NO_PROXY behavior. Also update repository links in README and localized docs (Chinese, Persian, Russian) to point to tiekoetter/Wikiless and update the package.json repository URL.