### PR TITLE
Potential fix for code scanning alert no. 8: Server-side URL redirect

### DIFF
--- a/__tests__/routes.test.js
+++ b/__tests__/routes.test.js
@@ -181,9 +181,31 @@ describe('Routes wiring', () => {
     expect(res.headers.location).toBe('/xyz');
   });
 
+  it('POST /preferences preserves safe redirect query strings', async () => {
+    const res = await request(app)
+      .post('/preferences?back=%2Fwiki%2FFoo%3Flang%3Dfr%23History')
+      .send('theme=dark&default_lang=fr');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/wiki/Foo?lang=fr#History');
+  });
+
   it('POST /preferences rejects unsafe redirect paths', async () => {
     const res = await request(app)
       .post('/preferences?back=//evil.test')
+      .send('theme=dark&default_lang=fr');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/');
+  });
+
+  it.each([
+    'https://evil.test/phish',
+    'https%3A%2F%2Fevil.test%2Fphish',
+    '%2F%2Fevil.test',
+    '%2F%5Cevil.test',
+    'javascript:alert(1)',
+  ])('POST /preferences rejects unsafe redirect target %s', async (back) => {
+    const res = await request(app)
+      .post(`/preferences?back=${back}`)
       .send('theme=dark&default_lang=fr');
     expect(res.status).toBe(302);
     expect(res.headers.location).toBe('/');

--- a/src/routes.js
+++ b/src/routes.js
@@ -204,29 +204,28 @@ module.exports = (app, utils) => {
     return res.send(preferencesPage(req, res))
   })
 
-  // Helper to validate safe redirect paths
-  function isSafeRedirectPath(path) {
-    // Must start with a single slash, not double slash, not contain backslash, not contain protocol
-    return (
-      typeof path === 'string' &&
-      path.startsWith('/') &&
-      !path.startsWith('//') &&
-      !path.includes('\\') &&
-      !/^\/(http|https):/.test(path)
-    );
+  // Helper to sanitize redirect target using a strict internal allowlist
+  function sanitizeBackRedirect(back) {
+    const allowedRedirects = new Set([
+      '/',
+      '/preferences',
+      '/about',
+    ])
+
+    if (typeof back !== 'string') {
+      return '/'
+    }
+
+    return allowedRedirects.has(back) ? back : '/'
   }
 
   app.post('/preferences', (req, res) => {
     const theme = req.body.theme
     const default_lang = req.body.default_lang
-    let back = req.query.back
+    const back = sanitizeBackRedirect(req.query.back)
 
     res.cookie('theme', theme, { maxAge: 365 * 24 * 60 * 60 * 1000, httpOnly: true })
     res.cookie('default_lang', default_lang, { maxAge: 365 * 24 * 60 * 60 * 1000, httpOnly: true })
-
-    if (!isSafeRedirectPath(back)) {
-      back = '/'
-    }
 
     return res.redirect(back)
   })

--- a/src/routes.js
+++ b/src/routes.js
@@ -204,19 +204,25 @@ module.exports = (app, utils) => {
     return res.send(preferencesPage(req, res))
   })
 
-  // Helper to sanitize redirect target using a strict internal allowlist
+  // Helper to sanitize redirect targets to same-origin internal paths.
   function sanitizeBackRedirect(back) {
-    const allowedRedirects = new Set([
-      '/',
-      '/preferences',
-      '/about',
-    ])
-
     if (typeof back !== 'string') {
       return '/'
     }
 
-    return allowedRedirects.has(back) ? back : '/'
+    const localOrigin = 'https://wikiless.local'
+    let parsed
+    try {
+      parsed = new URL(back, localOrigin)
+    } catch(err) {
+      return '/'
+    }
+
+    if(parsed.origin !== localOrigin || parsed.pathname.includes('\\')) {
+      return '/'
+    }
+
+    return `${parsed.pathname}${parsed.search}${parsed.hash}`
   }
 
   app.post('/preferences', (req, res) => {


### PR DESCRIPTION
Potential fix for [https://github.com/tiekoetter/Wikiless/security/code-scanning/8](https://github.com/tiekoetter/Wikiless/security/code-scanning/8)

To fix this safely, avoid redirecting to arbitrary user-provided paths and instead allow only known-safe internal destinations.  
Best approach here (without changing intended functionality too much): keep `back` support but map it through an allowlist of exact internal routes (for example `/`, `/preferences`, `/about`) and fall back to `/` for anything else.

In `src/routes.js` around the existing helper and `/preferences` POST handler:

- Replace the current `isSafeRedirectPath` helper with an allowlist-based helper (e.g., `sanitizeBackRedirect`).
- In the handler, pass `req.query.back` through this helper and always redirect to the sanitized result.

This removes open-redirect risk and gives deterministic behavior for unsupported `back` values.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
