### PR TITLE
fix: Add CSRF protection and rate limiting

### DIFF
--- a/__tests__/routes.test.js
+++ b/__tests__/routes.test.js
@@ -2,6 +2,7 @@ const express = require('express');
 const request = require('supertest');
 const cookieParser = require('cookie-parser');
 const bodyParser = require('body-parser');
+const lusca = require('lusca');
 const crypto = require('crypto');
 
 // Mock config
@@ -27,17 +28,40 @@ const utils = utilsFactory();
 
 const routes = require('../src/routes');
 let app;
+function testCsrfImpl() {
+  const tokens = new Set();
+  return {
+    create() {
+      const token = `csrf-${tokens.size}`;
+      tokens.add(token);
+      return {
+        token,
+        validate(req, value) {
+          return tokens.has(value);
+        },
+      };
+    },
+  };
+}
+
+async function csrfRequest(path = '/preferences') {
+  const res = await request(app).get(path);
+  const token = res.text.match(/name="_csrf" value="([^"]+)"/)[1];
+  return { token };
+}
+
 beforeEach(() => {
   jest.clearAllMocks();
   utils.handleWikiPage.mockImplementation((req, res, prefix) => res.status(200).send(`HANDLED_${prefix}`));
   utils.proxyMedia.mockImplementation(async () => ({ success: true, path: 'DUMMY_PATH' }));
-  utils.preferencesPage.mockImplementation(() => '<html>PREFERENCES</html>');
+  utils.preferencesPage.mockImplementation((req) => `<html>PREFERENCES<input type="hidden" name="_csrf" value="${req.csrfToken()}"></html>`);
   utils.customLogos.mockImplementation(() => false);
   utils.wikilessLogo.mockImplementation(() => 'LOGO_PATH');
   utils.wikilessFavicon.mockImplementation(() => 'FAVICON_PATH');
   app = express();
   app.use(cookieParser());
   app.use(bodyParser.urlencoded({ extended: true }));
+  app.use(lusca.csrf({ impl: testCsrfImpl() }));
 
   // Stub sendFile to avoid FS I/O
   app.use((req, res, next) => {
@@ -47,6 +71,13 @@ beforeEach(() => {
   });
 
   routes(app, utils);
+
+  app.use((err, req, res, next) => {
+    if(err.statusCode === 403 && /^CSRF token/.test(err.message)) {
+      return res.sendStatus(403);
+    }
+    return next(err);
+  });
 });
 
 describe('Routes wiring', () => {
@@ -163,9 +194,10 @@ describe('Routes wiring', () => {
   });
 
   it('POST /preferences -> set cookies + redirect', async () => {
+    const csrf = await csrfRequest();
     const res = await request(app)
       .post('/preferences?back=/xyz')
-      .send('theme=dark&default_lang=fr');
+      .send(`theme=dark&default_lang=fr&_csrf=${csrf.token}`);
     expect(res.status).toBe(302);
     expect(res.headers.location).toBe('/xyz');
     const ck = res.headers['set-cookie'].join(' ');
@@ -174,25 +206,28 @@ describe('Routes wiring', () => {
   });
 
   it('POST /preferences accepts encoded safe redirect paths', async () => {
+    const csrf = await csrfRequest();
     const res = await request(app)
       .post('/preferences?back=%2Fxyz')
-      .send('theme=dark&default_lang=fr');
+      .send(`theme=dark&default_lang=fr&_csrf=${csrf.token}`);
     expect(res.status).toBe(302);
     expect(res.headers.location).toBe('/xyz');
   });
 
   it('POST /preferences preserves safe redirect query strings', async () => {
+    const csrf = await csrfRequest();
     const res = await request(app)
       .post('/preferences?back=%2Fwiki%2FFoo%3Flang%3Dfr%23History')
-      .send('theme=dark&default_lang=fr');
+      .send(`theme=dark&default_lang=fr&_csrf=${csrf.token}`);
     expect(res.status).toBe(302);
     expect(res.headers.location).toBe('/wiki/Foo?lang=fr#History');
   });
 
   it('POST /preferences rejects unsafe redirect paths', async () => {
+    const csrf = await csrfRequest();
     const res = await request(app)
       .post('/preferences?back=//evil.test')
-      .send('theme=dark&default_lang=fr');
+      .send(`theme=dark&default_lang=fr&_csrf=${csrf.token}`);
     expect(res.status).toBe(302);
     expect(res.headers.location).toBe('/');
   });
@@ -204,9 +239,10 @@ describe('Routes wiring', () => {
     '%2F%5Cevil.test',
     'javascript:alert(1)',
   ])('POST /preferences rejects unsafe redirect target %s', async (back) => {
+    const csrf = await csrfRequest();
     const res = await request(app)
       .post(`/preferences?back=${back}`)
-      .send('theme=dark&default_lang=fr');
+      .send(`theme=dark&default_lang=fr&_csrf=${csrf.token}`);
     expect(res.status).toBe(302);
     expect(res.headers.location).toBe('/');
   });
@@ -214,7 +250,8 @@ describe('Routes wiring', () => {
   it('GET /preferences -> render preferences page', async () => {
     const res = await request(app).get('/preferences');
     expect(res.status).toBe(200);
-    expect(res.text).toBe('<html>PREFERENCES</html>');
+    expect(res.text).toContain('<html>PREFERENCES');
+    expect(res.text).toContain('name="_csrf"');
     expect(utils.preferencesPage).toHaveBeenCalled();
   });
 
@@ -284,15 +321,19 @@ describe('Routes wiring', () => {
   });
 
   it('POST DownloadAsPdf without page redirects home', async () => {
-    const res = await request(app).post('/wiki/Special:DownloadAsPdf').send('');
+    const csrf = await csrfRequest();
+    const res = await request(app)
+      .post('/wiki/Special:DownloadAsPdf')
+      .send(`_csrf=${csrf.token}`);
     expect(res.status).toBe(302);
     expect(res.headers.location).toBe('/');
   });
 
   it('POST DownloadAsPdf redirects to the PDF workflow', async () => {
+    const csrf = await csrfRequest();
     const res = await request(app)
       .post('/wiki/Special:DownloadAsPdf')
-      .send('page=Foo&lang=fr');
+      .send(`page=Foo&lang=fr&_csrf=${csrf.token}`);
     expect(res.status).toBe(302);
     expect(res.headers.location).toBe('/w/index.php?title=Special%3ADownloadAsPdf&page=Foo&action=redirect-to-electron&lang=fr');
   });

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -194,12 +194,15 @@ describe('Utils factory', () => {
       },
       'https://en.wikipedia.org/wiki/Foo',
       'oldid=1',
-      'en'
+      'en',
+      {},
+      'csrf-token'
     );
 
     expect(result.success).toBe(true);
     expect(result.html).toContain('<a href="/about">[ about ]</a>');
     expect(result.html).toContain('<a href="/preferences?back=/wiki/Foo?oldid=1">[ preferences ]</a>');
+    expect(result.html).toContain('<input type="hidden" name="_csrf" value="csrf-token">');
     expect(result.html).toContain('<input type="hidden" name="lang" value="en">');
     expect(result.html).not.toContain('p-wikibase-otherprojects');
     expect(result.html).toContain('href="/wiki/Foo?lang=fr"');
@@ -511,7 +514,8 @@ describe('Utils factory', () => {
       'https://en.wikipedia.org/w/index.php',
       'lang=en',
       'en',
-      req.cookies
+      req.cookies,
+      ''
     );
     expect(res.send).toHaveBeenCalledWith('PROCESSED_MODDED');
   });
@@ -571,8 +575,10 @@ describe('Utils factory', () => {
     const html = utils.preferencesPage({
       cookies: { default_lang: 'en', theme: 'dark' },
       query: { back: '/wiki/Foo?lang=en' },
+      csrfToken: () => 'csrf-token',
     });
 
     expect(html).toContain('action="/preferences?back=%2Fwiki%2FFoo%3Flang%3Den"');
+    expect(html).toContain('<input type="hidden" name="_csrf" value="csrf-token">');
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,11 @@
         "compression": "^1.8.1",
         "cookie-parser": "^1.4.7",
         "express": "^5.2.1",
+        "express-rate-limit": "^8.5.2",
         "got": "^15.0.5",
         "http-proxy-agent": "^7.0.2",
         "https-proxy-agent": "^7.0.6",
+        "lusca": "^1.7.0",
         "node-html-parser": "^7.1.0",
         "redis": "^6.0.0"
       },
@@ -2696,6 +2698,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/express/node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -3332,6 +3352,15 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -4171,6 +4200,17 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lusca": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/lusca/-/lusca-1.7.0.tgz",
+      "integrity": "sha512-msnrplCfY7zaqlZBDEloCIKld+RUeMZVeWzSPaGUKeRXFlruNSdKg2XxCyR+zj6BqzcXhXlRnvcvx6rAGgsvMA==",
+      "dependencies": {
+        "tsscmp": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=0.8.x"
       }
     },
     "node_modules/make-dir": {
@@ -5518,6 +5558,15 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.x"
+      }
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
@@ -7879,6 +7928,14 @@
         }
       }
     },
+    "express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "requires": {
+        "ip-address": "^10.2.0"
+      }
+    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -8261,6 +8318,11 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="
     },
     "ipaddr.js": {
       "version": "1.9.1",
@@ -8893,6 +8955,14 @@
       "dev": true,
       "requires": {
         "yallist": "^3.0.2"
+      }
+    },
+    "lusca": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/lusca/-/lusca-1.7.0.tgz",
+      "integrity": "sha512-msnrplCfY7zaqlZBDEloCIKld+RUeMZVeWzSPaGUKeRXFlruNSdKg2XxCyR+zj6BqzcXhXlRnvcvx6rAGgsvMA==",
+      "requires": {
+        "tsscmp": "^1.0.5"
       }
     },
     "make-dir": {
@@ -9821,6 +9891,11 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "optional": true
+    },
+    "tsscmp": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="
     },
     "type-detect": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -8,9 +8,11 @@
     "compression": "^1.8.1",
     "cookie-parser": "^1.4.7",
     "express": "^5.2.1",
+    "express-rate-limit": "^8.5.2",
     "got": "^15.0.5",
     "http-proxy-agent": "^7.0.2",
     "https-proxy-agent": "^7.0.6",
+    "lusca": "^1.7.0",
     "node-html-parser": "^7.1.0",
     "redis": "^6.0.0"
   },

--- a/src/routes.js
+++ b/src/routes.js
@@ -2,6 +2,7 @@ module.exports = (app, utils) => {
   const config = require('../wikiless.config')
   const path = require('path')
   const crypto = require('crypto')
+  const rateLimit = require('express-rate-limit')
   const {
     customLogos,
     handleWikiPage,
@@ -10,6 +11,13 @@ module.exports = (app, utils) => {
     wikilessFavicon,
     wikilessLogo,
   } = utils
+
+  const filesystemRateLimit = rateLimit({
+    windowMs: 60 * 1000,
+    limit: 120,
+    standardHeaders: 'draft-8',
+    legacyHeaders: false
+  })
 
   app.all(/.*/, (req, res, next) => {
     let themeOverride = req.query.theme
@@ -33,7 +41,7 @@ module.exports = (app, utils) => {
     return next()
   })
 
-  app.get(/.*/, async (req, res, next) => {
+  app.get(/.*/, filesystemRateLimit, async (req, res, next) => {
     if(req.url.startsWith('/w/load.php')) {
       return res.sendStatus(404)
     }
@@ -170,7 +178,7 @@ module.exports = (app, utils) => {
     return handleWikiPage(req, res, '/wiki/Map')
   })
 
-  app.get('/api/rest_v1/page/pdf/:page', async (req, res, next) => {
+  app.get('/api/rest_v1/page/pdf/:page', filesystemRateLimit, async (req, res, next) => {
     if(!req.params.page) {
       return res.redirect('/')
     }
@@ -196,7 +204,7 @@ module.exports = (app, utils) => {
     return handleWikiPage(req, res, '/')
   })
 
-  app.get('/about', (req, res, next) => {
+  app.get('/about', filesystemRateLimit, (req, res, next) => {
     return res.sendFile(path.join(__dirname, '../static/about.html'))
   })
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -322,11 +322,11 @@ module.exports = function(redis, gotClient = null) {
       if (!redis.isOpen) await redis.connect();
       const cached = await redis.get(url);
       if (cached) {
-        console.log(`Got key ${url} from cache.`);
+        console.log('Got key %s from cache.', url);
         return { success: true, html: cached, processed: true, url };
       }
     } catch (err) {
-      console.error(`Redis GET error for ${url}:`, err);
+      console.error('Redis GET error for %s:', url, err);
     }
   
     try {
@@ -334,11 +334,11 @@ module.exports = function(redis, gotClient = null) {
         headers: { 'User-Agent': UA },
         timeout: { request: 10000 }
       }));
-      console.log(`Fetched ${url} from Wikipedia.`);
+      console.log('Fetched %s from Wikipedia.', url);
       return { success: true, html: body, processed: false, url };
     } catch (err) {
       const status = err.response?.statusCode ?? 'NO_RESPONSE';
-      console.error(`Download error for ${url}:`, err.code ?? err.message);
+      console.error('Download error for %s:', url, err.code ?? err.message);
       return {
         success: false,
         reason: status === 404 ? 'REDIRECT' : `INVALID_HTTP_RESPONSE: ${status}`,
@@ -389,7 +389,7 @@ module.exports = function(redis, gotClient = null) {
     return data
   }
 
-  this.processHtml = async (data, url, params, lang) => {
+  this.processHtml = async (data, url, params, lang, cookies = {}, csrfToken = '') => {
     if(this.validHtml(data.html)) {
       url = encodeURI(url)
       if(params) {
@@ -429,6 +429,9 @@ module.exports = function(redis, gotClient = null) {
       let forms = data.html.querySelectorAll('form')
       for(let i = 0; i < forms.length; i++) {
         forms[i].insertAdjacentHTML('afterbegin', `<input type="hidden" name="lang" value="${lang}">`)
+        if(csrfToken) {
+          forms[i].insertAdjacentHTML('afterbegin', `<input type="hidden" name="_csrf" value="${csrfToken}">`)
+        }
       }
       // remove #p-wikibase-otherprojects
       let wikibase_links = data.html.querySelector('#p-wikibase-otherprojects')
@@ -712,7 +715,8 @@ module.exports = function(redis, gotClient = null) {
 
     // wikiless params
     const down_params = new URLSearchParams(req.query).toString()
-    const process_html = await this.processHtml(result, url, down_params, lang, req.cookies)
+    const csrfToken = typeof req.csrfToken === 'function' ? req.csrfToken() : ''
+    const process_html = await this.processHtml(result, url, down_params, lang, req.cookies, csrfToken)
     if(process_html.success === true) {
       return res.send(this.applyUserMods(process_html.html.toString(), req.cookies.theme, lang, isMobile))
     }
@@ -870,6 +874,8 @@ module.exports = function(redis, gotClient = null) {
     lang_select += '</select>'
 
     const back = encodeURIComponent((req.query && req.query.back) || '/')
+    const csrfToken = typeof req.csrfToken === 'function' ? req.csrfToken() : ''
+    const csrfInput = csrfToken ? `<input type="hidden" name="_csrf" value="${csrfToken}">` : ''
 
     const html = `
       <!DOCTYPE html>
@@ -884,6 +890,7 @@ module.exports = function(redis, gotClient = null) {
           <div id="preferences">
             <h4>Preferences</h4>
             <form method="POST" action="/preferences?back=${back}">
+              ${csrfInput}
               <div class="setting">
                 <div class="label">
                   <label for="theme">Theme:</label>

--- a/src/wikiless.js
+++ b/src/wikiless.js
@@ -3,6 +3,8 @@ const compression = require('compression')
 const path = require('path')
 const express = require('express')
 const cookieParser = require('cookie-parser')
+const lusca = require('lusca')
+const crypto = require('crypto')
 const fs = require('fs')
 const app = express()
 const r = require('redis')
@@ -45,6 +47,34 @@ if(config.https_enabled) {
 }
 
 const http = require('http').Server(app)
+const csrfSecret = crypto.randomBytes(32)
+
+const csrfTokenImpl = {
+  create() {
+    const salt = crypto.randomBytes(16).toString('hex')
+    const digest = crypto.createHmac('sha256', csrfSecret).update(salt).digest('hex')
+    const token = `${salt}.${digest}`
+
+    return {
+      token,
+      validate(req, value) {
+        if(typeof value !== 'string') {
+          return false
+        }
+
+        const [valueSalt, valueDigest] = value.split('.')
+        if(!valueSalt || !valueDigest) {
+          return false
+        }
+
+        const expected = crypto.createHmac('sha256', csrfSecret).update(valueSalt).digest('hex')
+        const actualBuffer = Buffer.from(valueDigest, 'hex')
+        const expectedBuffer = Buffer.from(expected, 'hex')
+        return actualBuffer.length === expectedBuffer.length && crypto.timingSafeEqual(actualBuffer, expectedBuffer)
+      }
+    }
+  }
+}
 
 app.use((req, res, next) => {
   // set CSP rules and other headers to every request
@@ -79,6 +109,7 @@ if(config.redirect_http_to_https) {
 app.use(compression())
 app.use(cookieParser())
 app.use(bodyParser.urlencoded({ extended: true, limit: '10mb' }))
+app.use(lusca.csrf({ impl: csrfTokenImpl }))
 app.use('/static', express.static(path.join(__dirname, '../static')))
 app.use(express.static(path.join(__dirname, '../static')))
 app.use(express.static(path.join(__dirname, '../media')))
@@ -88,6 +119,13 @@ if(config.trust_proxy) {
 }
 
 require('./routes')(app, utils)
+
+app.use((err, req, res, next) => {
+  if(err.statusCode === 403 && /^CSRF token/.test(err.message)) {
+    return res.sendStatus(403)
+  }
+  return next(err)
+})
 
 const cacheControl = require('./cache_control.js')
 cacheControl.removeCacheFiles()


### PR DESCRIPTION
Integrate lusca CSRF protection and filesystem rate limiting across the app. A HMAC-based CSRF token implementation was added in src/wikiless.js and lusca.csrf() is mounted; CSRF tokens are injected into rendered forms via utils.processHtml (signature extended to accept cookies and csrfToken) and preferences HTML. express-rate-limit is applied to filesystem-related routes in src/routes.js to throttle requests. Tests were updated to mock lusca CSRF tokens and include tokens in POST requests; package.json and package-lock.json now include lusca and express-rate-limit. Also made small logging formatting changes and added an error handler that returns 403 on CSRF failures.