### PR TITLE
[codex] mock proxy agents in unit tests

### DIFF
--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -7,6 +7,18 @@ jest.mock('../wikiless.config', () => ({
   setexs: { wikipage: 3600 },
 }));
 
+jest.mock('http-proxy-agent', () => ({
+  HttpProxyAgent: jest.fn(function HttpProxyAgent(proxy) {
+    this.proxy = proxy;
+  }),
+}));
+
+jest.mock('https-proxy-agent', () => ({
+  HttpsProxyAgent: jest.fn(function HttpsProxyAgent(proxy) {
+    this.proxy = proxy;
+  }),
+}));
+
 const fs = require('fs').promises;
 const path = require('path');
 const { Readable } = require('stream');


### PR DESCRIPTION
## Summary

- Mock http-proxy-agent and https-proxy-agent in __tests__/utils.test.js.
- Keep the proxy option assertions focused on Wikiless wiring the agent option, without asking Jest's Node 22 VM module loader to link the real ESM proxy-agent packages.

## Root Cause

After the earlier ESM compatibility fix, #17 no longer fails across the whole matrix. The current #17 run passes Node 24 and Node 26, but Node 22 fails only in Jest with ERR_VM_MODULE_LINK_FAILURE while testing proxied downloads with https-proxy-agent@9.1.0. Running the same proxied download path under plain Node 22 succeeds, so this is a test harness issue rather than production runtime behavior.

## Validation

- Reproduced the #17 Node 22 failure locally with https-proxy-agent@9.1.0 installed temporarily.
- Confirmed plain Node 22 can import both proxy-agent packages and run the proxied download path successfully.
- After this change, the exact failing Node 22 Jest test passes.
- Full Node 22 Jest suite with #17-like dependency state: 81 passed.
- Restored lockfile install state and ran normal npm test: 81 passed.